### PR TITLE
(fix) Streamline Encounter and Observation save process

### DIFF
--- a/app/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/app/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -143,7 +143,7 @@ class GenericFormEntryViewModel(application: Application, private val state: Sav
     //TODO Replace this with method to get the authenticated user's reference
     val authenticatedUser = MockConstants.AUTHENTICATED_USER
     val participant = EncounterParticipantComponent()
-    participant.individual = Reference("Practitioner/${authenticatedUser.uuid}")
+    participant.individual = Reference("Practitioner/${authenticatedUser.providerUuid}")
     participant.individual.display = authenticatedUser.display
     participant.individual.type = "Practitioner"
     return participant

--- a/app/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/app/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -30,6 +30,7 @@ import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Condition
+import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.Encounter
 import org.hl7.fhir.r4.model.Encounter.EncounterParticipantComponent
 import org.hl7.fhir.r4.model.Observation
@@ -94,13 +95,42 @@ class GenericFormEntryViewModel(application: Application, private val state: Sav
     val appContext = getApplication<Application>().applicationContext
     val locationId = appContext.dataStore.data.first()[PreferenceKeys.LOCATION_ID]
 
+    bundle.entry
+      .mapNotNull { it.resource as? Encounter }
+      .forEach { encounter ->
+        encounter.apply {
+          subject = patientReference
+          id = encounterId
+          status = Encounter.EncounterStatus.FINISHED
+          partOf = Reference("Encounter/0f3b5ced-9d77-4753-bc35-2e5eb1e7bbc4")  // FIXME: Dynamically fetch visit reference
+          setPeriod(Period().apply { start = Date() })
+          addParticipant(createParticipant())
+          addLocation(Encounter.EncounterLocationComponent().apply {
+            location = Reference("Location/$locationId")  // Set the location reference
+          })
+
+          addType(CodeableConcept().apply {
+            coding = listOf(
+              Coding().apply {
+                system = "http://fhir.openmrs.org/code-system/encounter-type"
+                code = form.code
+                display = form.display
+              }
+            )
+          })
+          saveResourceToDatabase(this)
+        }
+      }
+
     bundle.entry.forEach {
       when (val resource = it.resource) {
         is Observation -> {
-          if (resource.hasCode()) {
+          if (resource.hasCode() && resource.hasValue()) {
             resource.id = generateUuid()
             resource.subject = patientReference
             resource.encounter = encounterReference
+            resource.effective = DateTimeType(Date())
+            resource.status = Observation.ObservationStatus.FINAL
             saveResourceToDatabase(resource)
           }
         }
@@ -110,29 +140,6 @@ class GenericFormEntryViewModel(application: Application, private val state: Sav
             resource.subject = patientReference
             resource.encounter = encounterReference
             saveResourceToDatabase(resource)
-          }
-        }
-        is Encounter -> {
-          resource.apply {
-            subject = patientReference
-            id = encounterId
-            status = Encounter.EncounterStatus.FINISHED
-            setPeriod(Period().apply { start = Date() })
-            addParticipant(createParticipant())
-            addLocation(Encounter.EncounterLocationComponent().apply {
-              location = Reference("Location/$locationId")  // Set the location reference
-            })
-
-            addType(CodeableConcept().apply {
-              coding = listOf(
-                Coding().apply {
-                  system = "http://fhir.openmrs.org/code-system/encounter-type"
-                  code = form.code
-                  display = form.display
-                }
-              )
-            })
-            saveResourceToDatabase(this)
           }
         }
       }


### PR DESCRIPTION
- Save Encounter 1st and only after associated Obs
- Only save Obs if it was assigned a value
- Assign an harcoded visit uuid (visit should exist on server already)
- Fixed provider uuid on encounter
- Added status and date to encounter