### PR TITLE
(chore) Filter encounters list to not display visits and prevent splash screen return

### DIFF
--- a/core/src/main/java/org/openmrs/android/fhir/SplashActivity.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/SplashActivity.kt
@@ -26,6 +26,6 @@ class SplashActivity : AppCompatActivity() {
         } else {
             startActivity(Intent(this, LoginActivity::class.java))
         }
-
+        finish()
     }
 }

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
@@ -70,7 +70,8 @@ class PatientDetailsViewModel(
         data.addPatientDetailData(patientResource)
         data.add(PatientDetailHeader(getString(R.string.header_encounters)))
         visits.forEach { (visit, encounters) ->
-            data.addVisitData(visit, encounters)
+            //Hide Facility visit details
+            //data.addVisitData(visit, encounters)
             encounters.forEach { encounter ->
                 data.addEncounterData(encounter)
             }

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
@@ -33,6 +33,7 @@ import org.hl7.fhir.r4.model.ResourceType
 import org.openmrs.android.fhir.MockConstants
 import org.openmrs.android.fhir.R
 import org.openmrs.android.fhir.MockConstants.DATE24_FORMATTER
+import org.openmrs.android.fhir.MockConstants.WRAP_ENCOUNTER
 import org.openmrs.android.helpers.OpenMRSHelper
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -70,8 +71,11 @@ class PatientDetailsViewModel(
         data.addPatientDetailData(patientResource)
         data.add(PatientDetailHeader(getString(R.string.header_encounters)))
         visits.forEach { (visit, encounters) ->
-            //Hide Facility visit details
-            //data.addVisitData(visit, encounters)
+
+            if (!WRAP_ENCOUNTER) {
+                data.addVisitData(visit, encounters)
+            }
+
             encounters.forEach { encounter ->
                 data.addEncounterData(encounter)
             }
@@ -87,10 +91,11 @@ class PatientDetailsViewModel(
             .toPatientItem(0)
             .let { patientItem ->
                 runBlocking {
-                    patientItem.isSynced = fhirEngine.getLocalChanges(ResourceType.Patient, patientItem.resourceId).isEmpty()
+                    patientItem.isSynced =
+                        fhirEngine.getLocalChanges(ResourceType.Patient, patientItem.resourceId).isEmpty()
                     add(PatientDetailOverview(patientItem, firstInGroup = true))
-                    if(patientItem.isSynced !=null && !patientItem.isSynced!!){
-                        add(PatientUnsynced(false,false))
+                    if (patientItem.isSynced != null && !patientItem.isSynced!!) {
+                        add(PatientUnsynced(false, false))
                     }
                 }
                 // Add other patient details if necessary
@@ -184,7 +189,7 @@ data class PatientDetailOverview(
 data class PatientUnsynced(
     override val firstInGroup: Boolean = false,
     override val lastInGroup: Boolean = false
-    ):PatientDetailData
+) : PatientDetailData
 
 data class PatientDetailObservation(
     val observation: PatientListViewModel.ObservationItem,


### PR DESCRIPTION
### Description
**Encounters List Filtering**: Filters out visits from the encounters list, ensuring only relevant data (encounters) is displayed.

**Splash Screen Prevention**: Addresses an issue where returning to the splash screen could occur unintentionally. This fix prevents the splash screen from being shown after app initialization.

CC: @icrc-psousa 