### PR TITLE
Added spotless

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,13 +6,12 @@ buildscript {
     google()
     mavenCentral()
     gradlePluginPortal()
-
   }
   dependencies {
     classpath("com.android.tools.build:gradle:8.5.2")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
     classpath("com.google.gms:google-services:4.4.2")
-    classpath("com.diffplug.spotless:spotless-plugin-gradle:6.22.0")
+    classpath("com.diffplug.spotless:spotless-plugin-gradle:6.6.0")
     classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7")
 
     // NOTE: Do not place your application dependencies here; they belong
@@ -20,11 +19,10 @@ buildscript {
   }
 }
 
-
- plugins {
-    id("com.google.devtools.ksp") version "2.0.0-1.0.21" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
-  }
+plugins {
+  id("com.google.devtools.ksp") version "2.0.0-1.0.21" apply false
+  id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+}
 
 allprojects {
   repositories {
@@ -35,12 +33,57 @@ allprojects {
       name = "google-android-fhir"
       url = uri("https://maven.pkg.github.com/google/android-fhir")
       credentials {
-        username = localPropertyOrEnv(providers,"gpr.user", "USERNAME")
-        password = localPropertyOrEnv(providers,"gpr.key", "TOKEN")
+        username = localPropertyOrEnv(providers, "gpr.user", "USERNAME")
+        password = localPropertyOrEnv(providers, "gpr.key", "TOKEN")
       }
     }
   }
 
+  configureSpotless()
+}
+
+fun Project.configureSpotless() {
+  val ktlintVersion = "0.41.0"
+  val ktlintOptions = mapOf("indent_size" to "2", "continuation_indent_size" to "2")
+  apply(plugin = "com.diffplug.spotless")
+  configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+    ratchetFrom = "origin/main" // only format files which have changed since origin/master
+    kotlin {
+      target("**/*.kt")
+      targetExclude("**/build/")
+      targetExclude("**/*_Generated.kt")
+      ktlint(ktlintVersion).userData(ktlintOptions)
+      ktfmt().googleStyle()
+      licenseHeaderFile(
+        "${project.rootProject.projectDir}/license-header.txt",
+        "package|import|class|object|sealed|open|interface|abstract "
+        // It is necessary to tell spotless the top level of a file in order to apply config to it
+        // See: https://github.com/diffplug/spotless/issues/135
+        )
+    }
+    kotlinGradle {
+      target("*.gradle.kts")
+      ktlint(ktlintVersion).userData(ktlintOptions)
+      ktfmt().googleStyle()
+    }
+    format("xml") {
+      target("**/*.xml")
+      targetExclude("**/build/", ".idea/")
+      prettier(mapOf("prettier" to "2.0.5", "@prettier/plugin-xml" to "0.13.0"))
+        .config(mapOf("parser" to "xml", "tabWidth" to 4))
+    }
+    // Creates one off SpotlessApply task for generated files
+    com.diffplug.gradle.spotless.KotlinExtension(this).apply {
+      target("**/*_Generated.kt")
+      ktlint(ktlintVersion).userData(ktlintOptions)
+      ktfmt().googleStyle()
+      licenseHeaderFile(
+        "${project.rootProject.projectDir}/license-header.txt",
+        "package|import|class|object|sealed|open|interface|abstract "
+      )
+      createIndependentApplyTask("spotlessGenerated")
+    }
+  }
 }
 
 fun localPropertyOrEnv(providers: ProviderFactory, propertyName: String, envName: String): String? =


### PR DESCRIPTION
Fixes #70,

Added spotless similar to google,
https://github.com/google/android-fhir/blob/openmrs/buildSrc/src/main/kotlin/SpotlessConfig.kt

`6.22.0` causes an error while build

```
Build file '/Users/ameen4455/Documents/Code/ICRC/openmrs-android-fhir/app/build.gradle.kts' line: 4

An exception occurred applying plugin request [id: 'kotlin-android']
> Failed to apply plugin 'kotlin-android'.
> Cannot change dependencies of dependency configuration ':app:spotless-1972458211' after it has been resolved.
```

So I had to downgrade it to similar version of google - `6.6.0`.

After adding config, I was able to run `./gradlew spotlessCheck` & `./gradlew spotlessApply`
