### PR TITLE
(refactor) updated cookie interceptor to only take jsessionID

### DIFF
--- a/core/src/main/java/org/openmrs/android/fhir/data/remote/interceptor/AddCookiesInterceptor.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/data/remote/interceptor/AddCookiesInterceptor.kt
@@ -42,13 +42,14 @@ import org.openmrs.android.fhir.data.PreferenceKeys
 class AddCookiesInterceptor(private val context: Context) : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
+    val originalRequest = chain.request()
     val builder: Request.Builder = chain.request().newBuilder()
-    runBlocking {
-      val prefCookies: Set<String> =
-        context.dataStore.data.first()[PreferenceKeys.PREF_COOKIES]?.toMutableSet()
-          ?: mutableSetOf()
-      for (cookie in prefCookies) {
-        builder.addHeader("Cookie", cookie)
+    if (originalRequest.url.toString().contains("idgen")) {
+      runBlocking {
+        val prefCookies: Set<String> =
+          context.dataStore.data.first()[PreferenceKeys.PREF_COOKIES]?.toMutableSet()
+            ?: mutableSetOf()
+        builder.addHeader("Cookie", prefCookies.joinToString("; "))
       }
     }
     return chain.proceed(builder.build())


### PR DESCRIPTION
- currently only `JSESSIONID` is required for `idgen` endpoints.