### PR TITLE
Refactored logging to fix the application diagnostics.

### DIFF
--- a/core/src/main/java/org/openmrs/android/fhir/FhirApplication.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/FhirApplication.kt
@@ -47,6 +47,7 @@ import org.openmrs.android.fhir.data.PreferenceKeys
 import org.openmrs.android.fhir.data.RestApiManager
 import org.openmrs.android.fhir.di.AppComponent
 import org.openmrs.android.fhir.di.DaggerAppComponent
+import org.openmrs.android.fhir.extensions.FileLoggingTree
 import timber.log.Timber
 
 class FhirApplication : Application(), DataCaptureConfig.Provider {
@@ -61,11 +62,10 @@ class FhirApplication : Application(), DataCaptureConfig.Provider {
 
   override fun onCreate() {
     super.onCreate()
-    Timber.e("FHIR Application started. Test Error log. Is Debug " + BuildConfig.DEBUG)
+    Timber.e("FHIR Application started. Test Error log. Is Debug %s", BuildConfig.DEBUG)
     Timber.d("FHIR Application started. Test Debug log")
-    if (BuildConfig.DEBUG) {
-      Timber.plant(Timber.DebugTree())
-    }
+    val loggingMaxFileSize = 5 * 1024 * 1024L // 5MB
+    Timber.plant(FileLoggingTree(this, loggingMaxFileSize))
     FhirEngineProvider.init(
       FhirEngineConfiguration(
         enableEncryptionIfSupported = false,
@@ -76,7 +76,7 @@ class FhirApplication : Application(), DataCaptureConfig.Provider {
           httpLogger =
             HttpLogger(
               HttpLogger.Configuration(
-                if (BuildConfig.DEBUG) HttpLogger.Level.BODY else HttpLogger.Level.BASIC,
+                HttpLogger.Level.BODY,
               ),
             ) {
               Timber.tag("App-HttpLog").d(it)

--- a/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
@@ -73,6 +73,7 @@ import org.openmrs.android.fhir.data.PreferenceKeys
 import org.openmrs.android.fhir.data.database.AppDatabase
 import org.openmrs.android.fhir.data.database.model.SyncStatus
 import org.openmrs.android.fhir.databinding.ActivityMainBinding
+import org.openmrs.android.fhir.extensions.UncaughtExceptionHandler
 import org.openmrs.android.fhir.extensions.getApplicationLogs
 import org.openmrs.android.fhir.extensions.saveToFile
 import org.openmrs.android.fhir.extensions.showSnackBar
@@ -103,6 +104,9 @@ class MainActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    Thread.setDefaultUncaughtExceptionHandler(
+      UncaughtExceptionHandler(this, Thread.getDefaultUncaughtExceptionHandler()),
+    )
     (this.application as FhirApplication).appComponent.inject(this)
     binding = ActivityMainBinding.inflate(layoutInflater)
     loginRepository = LoginRepository.getInstance(applicationContext)
@@ -487,10 +491,10 @@ class MainActivity : AppCompatActivity() {
           for (session in syncSessions) {
             fileContent.append("Start Time: ${session.startTime}\n")
             fileContent.append(
-              "Downloaded Patients: ${session.downloadedPatients}/${session.totalPatientsToDownload}\n",
+              "Downloaded Resources: ${session.downloadedPatients}/${session.totalPatientsToDownload}\n",
             )
             fileContent.append(
-              "Uploaded Patients: ${session.uploadedPatients}/${session.totalPatientsToUpload}\n",
+              "Uploaded Resources: ${session.uploadedPatients}/${session.totalPatientsToUpload}\n",
             )
             fileContent.append("Completion Time: ${session.completionTime ?: "In Progress"}\n")
             fileContent.append("Status: ${session.status}\n")

--- a/core/src/main/java/org/openmrs/android/fhir/data/remote/interceptor/ReceivedCookiesInterceptor.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/data/remote/interceptor/ReceivedCookiesInterceptor.kt
@@ -41,7 +41,7 @@ class ReceivedCookiesInterceptor(private val context: Context) : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     val originalResponse: Response = chain.proceed(chain.request())
-    //only add the jsession cookie from session request.
+    // only add the jsession cookie from session request.
     if (
       chain.request().url.encodedPath.contains("session") and
         originalResponse.headers("Set-Cookie").isNotEmpty()

--- a/core/src/main/java/org/openmrs/android/fhir/extensions/FileLoggingTree.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/extensions/FileLoggingTree.kt
@@ -1,0 +1,92 @@
+/*
+* BSD 3-Clause License
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.openmrs.android.fhir.extensions
+
+import android.content.Context
+import android.util.Log
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileWriter
+import java.io.IOException
+import org.openmrs.android.fhir.extensions.FileLoggingTree.Companion.APPLICATION_LOG_FILE_NAME
+import timber.log.Timber
+
+class FileLoggingTree(context: Context, private val maxFileSize: Long) : Timber.Tree() {
+
+  private val logFile: File = File(context.filesDir, APPLICATION_LOG_FILE_NAME)
+
+  override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+    writeLogToFile("$priority/$tag: $message")
+  }
+
+  private fun writeLogToFile(log: String) {
+    try {
+      if (!logFile.exists()) {
+        logFile.createNewFile()
+      }
+
+      // Check if the file size exceeds the maximum threshold
+      if (logFile.length() > maxFileSize) {
+        trimLogFile()
+      }
+
+      // Append the log to the file
+      FileWriter(logFile, true).use { writer -> writer.appendLine(log) }
+    } catch (e: IOException) {
+      Log.e("FileLoggingTree", "Failed to write log to file", e)
+    }
+  }
+
+  private fun trimLogFile() {
+    try {
+      val trimmedContent = StringBuilder()
+      BufferedReader(logFile.reader()).useLines { lines ->
+        val allLines = lines.toList()
+        val deleteCount = (allLines.size * 0.1).toInt()
+        val startIndex = deleteCount
+        for (i in startIndex until allLines.size) {
+          trimmedContent.appendLine(allLines[i])
+        }
+      }
+      // Overwrite the file with the trimmed content
+      FileWriter(logFile, false).use { writer -> writer.write(trimmedContent.toString()) }
+    } catch (e: IOException) {
+      Log.e("FileLoggingTree", "Failed to trim log file", e)
+    }
+  }
+
+  companion object {
+    const val APPLICATION_LOG_FILE_NAME = "app_logs.txt"
+  }
+}
+
+fun getApplicationLogs(context: Context): File {
+  val logFile = File(context.filesDir, APPLICATION_LOG_FILE_NAME)
+  return logFile
+}

--- a/core/src/main/java/org/openmrs/android/fhir/extensions/UncaughtExceptionHandler.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/extensions/UncaughtExceptionHandler.kt
@@ -1,0 +1,53 @@
+/*
+* BSD 3-Clause License
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.openmrs.android.fhir.extensions
+
+import android.content.Context
+import android.os.Process
+import kotlin.system.exitProcess
+import timber.log.Timber
+
+/*
+Logs the stacktrace of unhandled exception,
+hence it is handled by FileLoggingTree.kt and added to the application log file.
+*/
+class UncaughtExceptionHandler(
+  val context: Context,
+  private val defaultUncaughtHandler: Thread.UncaughtExceptionHandler?,
+) : Thread.UncaughtExceptionHandler {
+  override fun uncaughtException(thread: Thread, exception: Throwable) {
+    Timber.tag("App-ExceptionLog").d(exception.stackTraceToString())
+    if (defaultUncaughtHandler != null) {
+      defaultUncaughtHandler.uncaughtException(thread, exception)
+    } else {
+      Process.killProcess(Process.myPid())
+      exitProcess(0)
+    }
+  }
+}

--- a/core/src/main/java/org/openmrs/android/fhir/extensions/Utils.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/extensions/Utils.kt
@@ -65,12 +65,6 @@ fun showSnackBar(
   snackBar.show()
 }
 
-fun getApplicationLogs(context: Context): File {
-  val logFile = File(context.cacheDir, "app_logs.txt")
-  Runtime.getRuntime().exec("logcat -d -f ${logFile.absolutePath}")
-  return logFile
-}
-
 fun saveToFile(context: Context, fileName: String, content: String): File? {
   return try {
     val fileDir = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)


### PR DESCRIPTION
Fixes #113 

Issue: In the release version of the app, logcat logs were inaccessible.
Fix: Replaced the existing logic with a rolling file mechanism to store logs, with a maximum size of 5MB.
Note: We can discuss integrating CrashAnalytics in the future for improved log management and reference.