### PR TITLE
(feat) Load FHIR questionnaires from database

### DIFF
--- a/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
@@ -75,6 +75,7 @@ import org.openmrs.android.fhir.data.database.AppDatabase
 import org.openmrs.android.fhir.data.database.model.SyncStatus
 import org.openmrs.android.fhir.databinding.ActivityMainBinding
 import org.openmrs.android.fhir.extensions.UncaughtExceptionHandler
+import org.openmrs.android.fhir.extensions.checkAndDeleteLogFile
 import org.openmrs.android.fhir.extensions.getApplicationLogs
 import org.openmrs.android.fhir.extensions.saveToFile
 import org.openmrs.android.fhir.extensions.showSnackBar
@@ -406,6 +407,7 @@ class MainActivity : AppCompatActivity() {
     demoDataStore.clearAll()
     database.clearAllTables()
     authStateManager.resetBasicAuthCredentials()
+    checkAndDeleteLogFile(applicationContext)
   }
 
   private fun handleAuthNavigation(

--- a/core/src/main/java/org/openmrs/android/fhir/adapters/PatientDetailsRecyclerViewAdapter.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/adapters/PatientDetailsRecyclerViewAdapter.kt
@@ -284,7 +284,7 @@ class PatientDetailsEncounterItemViewHolder(
         onEditEncounterClick(
           encounter.encounterId ?: "",
           encounter.formDisplay ?: "",
-          encounter.formResource ?: "",
+          encounter.encounterType ?: "",
         )
       }
     }

--- a/core/src/main/java/org/openmrs/android/fhir/auth/AuthStateManager.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/auth/AuthStateManager.kt
@@ -226,6 +226,10 @@ class AuthStateManager private constructor(private val context: Context) {
     context.dataStore.edit { pref -> pref[failedAttemptsKey] = value }
   }
 
+  suspend fun clearAuthDataStore() {
+    context.dataStore.edit { it.clear() }
+  }
+
   companion object {
     @SuppressLint("StaticFieldLeak") private var INSTANCE: AuthStateManager? = null
 

--- a/core/src/main/java/org/openmrs/android/fhir/data/remote/interceptor/AddCookiesInterceptor.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/data/remote/interceptor/AddCookiesInterceptor.kt
@@ -44,7 +44,10 @@ class AddCookiesInterceptor(private val context: Context) : Interceptor {
   override fun intercept(chain: Interceptor.Chain): Response {
     val originalRequest = chain.request()
     val builder: Request.Builder = chain.request().newBuilder()
-    if (originalRequest.url.toString().contains("idgen")) {
+    if (
+      originalRequest.url.toString().contains("idgen") ||
+        originalRequest.url.toString().contains("session")
+    ) {
       runBlocking {
         val prefCookies: Set<String> =
           context.dataStore.data.first()[PreferenceKeys.PREF_COOKIES]?.toMutableSet()

--- a/core/src/main/java/org/openmrs/android/fhir/di/AppComponent.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/di/AppComponent.kt
@@ -36,6 +36,7 @@ import org.openmrs.android.fhir.BasicLoginActivity
 import org.openmrs.android.fhir.LoginActivity
 import org.openmrs.android.fhir.MainActivity
 import org.openmrs.android.fhir.fragments.AddPatientFragment
+import org.openmrs.android.fhir.fragments.CreateEncountersFragment
 import org.openmrs.android.fhir.fragments.EditEncounterFragment
 import org.openmrs.android.fhir.fragments.EditPatientFragment
 import org.openmrs.android.fhir.fragments.GenericFormEntryFragment
@@ -91,4 +92,6 @@ interface AppComponent {
   fun inject(fragment: SettingsFragment)
 
   fun inject(activity: BasicLoginActivity)
+
+  fun inject(fragment: CreateEncountersFragment)
 }

--- a/core/src/main/java/org/openmrs/android/fhir/extensions/FileLoggingTree.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/extensions/FileLoggingTree.kt
@@ -86,6 +86,13 @@ class FileLoggingTree(context: Context, private val maxFileSize: Long) : Timber.
   }
 }
 
+fun checkAndDeleteLogFile(context: Context) {
+  val logFile = File(context.filesDir, APPLICATION_LOG_FILE_NAME)
+  if (logFile.exists()) {
+    logFile.delete()
+  }
+}
+
 fun getApplicationLogs(context: Context): File {
   val logFile = File(context.filesDir, APPLICATION_LOG_FILE_NAME)
   return logFile

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/CreateEncountersFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/CreateEncountersFragment.kt
@@ -43,6 +43,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.search.search
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -50,7 +51,6 @@ import org.hl7.fhir.r4.model.Questionnaire
 import org.openmrs.android.fhir.FhirApplication
 import org.openmrs.android.fhir.R
 import org.openmrs.android.fhir.databinding.CreateEncounterFragmentBinding
-import javax.inject.Inject
 
 class CreateEncountersFragment : Fragment(R.layout.create_encounter_fragment) {
   private var _binding: CreateEncounterFragmentBinding? = null
@@ -59,8 +59,7 @@ class CreateEncountersFragment : Fragment(R.layout.create_encounter_fragment) {
 
   private val args: CreateEncountersFragmentArgs by navArgs()
 
-  @Inject
-  lateinit var fhirEngine: FhirEngine
+  @Inject lateinit var fhirEngine: FhirEngine
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -90,8 +89,7 @@ class CreateEncountersFragment : Fragment(R.layout.create_encounter_fragment) {
     val buttonContainer = view.findViewById<LinearLayout>(R.id.button_container)
 
     lifecycleScope.launch(Dispatchers.IO) {
-      val forms = fhirEngine.search<Questionnaire> {
-      }
+      val forms = fhirEngine.search<Questionnaire> {}
       withContext(Dispatchers.Main) {
         for (form in forms) {
           setupFormButton(buttonContainer, form.resource)
@@ -101,8 +99,9 @@ class CreateEncountersFragment : Fragment(R.layout.create_encounter_fragment) {
   }
 
   private fun setupFormButton(parentView: ViewGroup, form: Questionnaire) {
-    val encounterType = form.code.firstOrNull()?.code
-      ?: throw IllegalArgumentException("No encounter type provided on questionnaire")
+    val encounterType =
+      form.code.firstOrNull()?.code
+        ?: throw IllegalArgumentException("No encounter type provided on questionnaire")
     val button =
       Button(context).apply {
         text = form.title
@@ -114,7 +113,7 @@ class CreateEncountersFragment : Fragment(R.layout.create_encounter_fragment) {
                   form.title,
                   encounterType,
                   args.patientId,
-                  form
+                  form,
                 ),
             )
         }

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/EditEncounterFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/EditEncounterFragment.kt
@@ -43,6 +43,7 @@ import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.QuestionnaireFragment
 import com.google.android.fhir.search.search
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.Questionnaire
 import org.openmrs.android.fhir.FhirApplication
@@ -50,7 +51,6 @@ import org.openmrs.android.fhir.MainActivity
 import org.openmrs.android.fhir.R
 import org.openmrs.android.fhir.di.ViewModelSavedStateFactory
 import org.openmrs.android.fhir.viewmodel.EditEncounterViewModel
-import javax.inject.Inject
 
 /**
  * A fragment representing Edit Encounter screen. This fragment is contained in a [MainActivity].
@@ -58,8 +58,7 @@ import javax.inject.Inject
 class EditEncounterFragment : Fragment(R.layout.generic_formentry_fragment) {
   @Inject lateinit var viewModelSavedStateFactory: ViewModelSavedStateFactory
 
-  @Inject
-  lateinit var fhirEngine: FhirEngine
+  @Inject lateinit var fhirEngine: FhirEngine
 
   private val viewModel: EditEncounterViewModel by viewModels { viewModelSavedStateFactory }
 
@@ -129,12 +128,16 @@ class EditEncounterFragment : Fragment(R.layout.generic_formentry_fragment) {
   private fun addQuestionnaireFragment(pair: Pair<String, String>) {
     if (pair.first.isNotBlank()) {
       lifecycleScope.launch {
-
         val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
 
-        val questionnaire = fhirEngine.search<Questionnaire> {}.filter {
-          questionnaire -> questionnaire.resource.code.any { it.code == encounterType }
-        }.firstOrNull()?.resource
+        val questionnaire =
+          fhirEngine
+            .search<Questionnaire> {}
+            .filter { questionnaire ->
+              questionnaire.resource.code.any { it.code == encounterType }
+            }
+            .firstOrNull()
+            ?.resource
 
         val questionnaireJson = parser.encodeResourceToString(questionnaire)
 

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/EditEncounterFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/EditEncounterFragment.kt
@@ -38,14 +38,19 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
+import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.QuestionnaireFragment
-import javax.inject.Inject
+import com.google.android.fhir.search.search
 import kotlinx.coroutines.launch
+import org.hl7.fhir.r4.model.Questionnaire
 import org.openmrs.android.fhir.FhirApplication
 import org.openmrs.android.fhir.MainActivity
 import org.openmrs.android.fhir.R
 import org.openmrs.android.fhir.di.ViewModelSavedStateFactory
 import org.openmrs.android.fhir.viewmodel.EditEncounterViewModel
+import javax.inject.Inject
 
 /**
  * A fragment representing Edit Encounter screen. This fragment is contained in a [MainActivity].
@@ -53,7 +58,12 @@ import org.openmrs.android.fhir.viewmodel.EditEncounterViewModel
 class EditEncounterFragment : Fragment(R.layout.generic_formentry_fragment) {
   @Inject lateinit var viewModelSavedStateFactory: ViewModelSavedStateFactory
 
+  @Inject
+  lateinit var fhirEngine: FhirEngine
+
   private val viewModel: EditEncounterViewModel by viewModels { viewModelSavedStateFactory }
+
+  private lateinit var encounterType: String
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -64,9 +74,9 @@ class EditEncounterFragment : Fragment(R.layout.generic_formentry_fragment) {
       requireArguments().getString("encounter_id")
         ?: throw IllegalArgumentException("Encounter ID is required")
 
-    val formResource =
-      requireArguments().getString("form_resource")
-        ?: throw IllegalArgumentException("Encounter ID is required")
+    encounterType =
+      requireArguments().getString("encounter_type")
+        ?: throw IllegalArgumentException("Encounter type is required")
 
     // Initialize the ViewModel using a factory
   }
@@ -119,11 +129,20 @@ class EditEncounterFragment : Fragment(R.layout.generic_formentry_fragment) {
   private fun addQuestionnaireFragment(pair: Pair<String, String>) {
     if (pair.first.isNotBlank()) {
       lifecycleScope.launch {
+
+        val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
+
+        val questionnaire = fhirEngine.search<Questionnaire> {}.filter {
+          questionnaire -> questionnaire.resource.code.any { it.code == encounterType }
+        }.firstOrNull()?.resource
+
+        val questionnaireJson = parser.encodeResourceToString(questionnaire)
+
         childFragmentManager.commit {
           add(
             R.id.form_entry_container,
             QuestionnaireFragment.builder()
-              .setQuestionnaire(pair.first)
+              .setQuestionnaire(questionnaireJson)
               .setQuestionnaireResponse(pair.second)
               .build(),
             QUESTIONNAIRE_FRAGMENT_TAG,

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/GenericFormEntryFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/GenericFormEntryFragment.kt
@@ -101,7 +101,7 @@ class GenericFormEntryFragment : Fragment(R.layout.generic_formentry_fragment) {
 
   private fun addQuestionnaireFragment() {
     childFragmentManager.commit {
-      if (viewModel.questionnaire.isEmpty()) {
+      if (args.questionnaire == null) {
         showSnackBar(
           requireActivity(),
           getString(R.string.questionnaire_error_message),

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/GenericFormEntryFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/GenericFormEntryFragment.kt
@@ -108,13 +108,6 @@ class GenericFormEntryFragment : Fragment(R.layout.generic_formentry_fragment) {
         )
         NavHostFragment.findNavController(this@GenericFormEntryFragment).navigateUp()
       } else {
-          val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
-          val questionnaireJson = parser.encodeResourceToString(args.questionnaire)
-          add(
-              R.id.form_entry_container,
-              QuestionnaireFragment.builder().setQuestionnaire(questionnaireJson).build(),
-              QUESTIONNAIRE_FRAGMENT_TAG,
-          )
         val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
         val questionnaireJson = parser.encodeResourceToString(args.questionnaire)
         add(

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/GenericFormEntryFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/GenericFormEntryFragment.kt
@@ -40,6 +40,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.navArgs
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.datacapture.QuestionnaireFragment
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -61,7 +63,7 @@ class GenericFormEntryFragment : Fragment(R.layout.generic_formentry_fragment) {
     super.onViewCreated(view, savedInstanceState)
     setUpActionBar()
     setHasOptionsMenu(true)
-    updateArguments(args.formResource, args.formCode)
+    updateArguments(args.formCode)
     (requireActivity().application as FhirApplication).appComponent.inject(this)
     onBackPressed()
     observeResourcesSaveAction()
@@ -92,10 +94,9 @@ class GenericFormEntryFragment : Fragment(R.layout.generic_formentry_fragment) {
     }
   }
 
-  private fun updateArguments(formResource: String, encounterId: String) {
-    requireArguments().putString(QUESTIONNAIRE_FILE_PATH_KEY, formResource)
+  private fun updateArguments(encounterId: String) {
     requireArguments().putString("encounter_id", encounterId)
-    //    requireArguments().putString(QUESTIONNAIRE_FILE_PATH_KEY, "screener-questionnaire.json")
+    requireArguments().putString("questionnaire_id", args.questionnaire?.idPart)
   }
 
   private fun addQuestionnaireFragment() {
@@ -107,11 +108,13 @@ class GenericFormEntryFragment : Fragment(R.layout.generic_formentry_fragment) {
         )
         NavHostFragment.findNavController(this@GenericFormEntryFragment).navigateUp()
       } else {
-        add(
-          R.id.form_entry_container,
-          QuestionnaireFragment.builder().setQuestionnaire(viewModel.questionnaire).build(),
-          QUESTIONNAIRE_FRAGMENT_TAG,
-        )
+          val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
+          val questionnaireJson = parser.encodeResourceToString(args.questionnaire);
+          add(
+              R.id.form_entry_container,
+              QuestionnaireFragment.builder().setQuestionnaire(questionnaireJson).build(),
+              QUESTIONNAIRE_FRAGMENT_TAG,
+          )
       }
     }
   }

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/PatientDetailsFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/PatientDetailsFragment.kt
@@ -203,12 +203,16 @@ class PatientDetailsFragment : Fragment() {
       .show()
   }
 
-  private fun onEditEncounterClick(encounterId: String, formDisplay: String, encounterType: String) {
+  private fun onEditEncounterClick(
+    encounterId: String,
+    formDisplay: String,
+    encounterType: String,
+  ) {
     findNavController()
       .navigate(
         PatientDetailsFragmentDirections.actionPatientDetailsToEditEncounterFragment(
           encounterId,
-          encounterType
+          encounterType,
         ),
       )
   }

--- a/core/src/main/java/org/openmrs/android/fhir/fragments/PatientDetailsFragment.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/fragments/PatientDetailsFragment.kt
@@ -203,12 +203,12 @@ class PatientDetailsFragment : Fragment() {
       .show()
   }
 
-  private fun onEditEncounterClick(encounterId: String, formDisplay: String, formResource: String) {
+  private fun onEditEncounterClick(encounterId: String, formDisplay: String, encounterType: String) {
     findNavController()
       .navigate(
         PatientDetailsFragmentDirections.actionPatientDetailsToEditEncounterFragment(
           encounterId,
-          formResource,
+          encounterType
         ),
       )
   }

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/EditEncounterViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/EditEncounterViewModel.kt
@@ -94,12 +94,14 @@ constructor(
     contitions = getConditionsEncounterId(encounterId)
     patientReference = encounter.subject
     try {
-
       val parser = FhirContext.forCached(FhirVersionEnum.R4).newJsonParser()
 
-      questionnaire = fhirEngine.search<Questionnaire> {}.filter {
-          questionnaire -> questionnaire.resource.code.any { it.code == encounterType }
-      }.first().resource
+      questionnaire =
+        fhirEngine
+          .search<Questionnaire> {}
+          .filter { questionnaire -> questionnaire.resource.code.any { it.code == encounterType } }
+          .first()
+          .resource
 
       val questionnaireJson = parser.encodeResourceToString(questionnaire)
 

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -33,8 +33,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import ca.uhn.fhir.context.FhirContext
-import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
 import com.google.android.fhir.search.search
@@ -46,7 +44,6 @@ import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import okio.FileNotFoundException
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -33,16 +33,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import ca.uhn.fhir.context.FhirContext
-import ca.uhn.fhir.context.FhirVersionEnum
 import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.datacapture.mapping.ResourceMapper
+import com.google.android.fhir.search.search
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import java.time.ZoneId
-import java.util.Date
-import java.util.UUID
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import okio.FileNotFoundException
@@ -64,11 +60,12 @@ import org.openmrs.android.fhir.MockConstants
 import org.openmrs.android.fhir.auth.dataStore
 import org.openmrs.android.fhir.data.PreferenceKeys
 import org.openmrs.android.fhir.di.ViewModelAssistedFactory
-import org.openmrs.android.fhir.extensions.readFileFromAssets
-import org.openmrs.android.fhir.fragments.GenericFormEntryFragment
 import org.openmrs.android.helpers.OpenMRSHelper
 import org.openmrs.android.helpers.OpenMRSHelper.MiscHelper
 import org.openmrs.android.helpers.OpenMRSHelper.UserHelper
+import java.time.ZoneId
+import java.util.Date
+import java.util.UUID
 
 /** ViewModel for Generic questionnaire screen {@link GenericFormEntryFragment}. */
 class GenericFormEntryViewModel
@@ -86,17 +83,7 @@ constructor(
     ): GenericFormEntryViewModel
   }
 
-  val questionnaire: String
-    get() = getQuestionnaireJson()
-
   val isResourcesSaved = MutableLiveData<Boolean>()
-
-  private val questionnaireResource: Questionnaire
-    get() =
-      FhirContext.forCached(FhirVersionEnum.R4).newJsonParser().parseResource(questionnaire)
-        as Questionnaire
-
-  private var questionnaireJson: String? = null
 
   suspend fun createWrapperVisit(patientId: String): Encounter {
     val localDate = Date().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
@@ -146,7 +133,22 @@ constructor(
    */
   fun saveEncounter(questionnaireResponse: QuestionnaireResponse, form: Form, patientId: String) {
     viewModelScope.launch {
-      val bundle = ResourceMapper.extract(questionnaireResource, questionnaireResponse)
+
+      val questionnaireId = state.get<String>("questionnaire_id")
+
+      if (questionnaireId.isNullOrBlank()) {
+        throw IllegalArgumentException("No questionnaire ID provided")
+      }
+
+      val questionnaire = fhirEngine.search<Questionnaire> {
+          filter(Resource.RES_ID, { value = of(questionnaireId) })
+      }.firstOrNull()?.resource
+
+      if (questionnaire == null) {
+        throw IllegalStateException("No questionnaire resource found with ID: $questionnaireId")
+      }
+
+      val bundle = ResourceMapper.extract(questionnaire, questionnaireResponse)
       val patientReference = Reference("Patient/$patientId")
       val encounterId = generateUuid()
 
@@ -276,22 +278,6 @@ constructor(
 
   private suspend fun saveResourceToDatabase(resource: Resource) {
     fhirEngine.create(resource)
-  }
-
-  private fun getQuestionnaireJson(): String {
-    questionnaireJson?.let {
-      return it
-    }
-
-    try {
-      questionnaireJson =
-        applicationContext.readFileFromAssets(
-          state[GenericFormEntryFragment.QUESTIONNAIRE_FILE_PATH_KEY]!!,
-        )
-    } catch (e: FileNotFoundException) {
-      return ""
-    }
-    return questionnaireJson!!
   }
 
   private fun generateUuid(): String {

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
@@ -196,7 +196,7 @@ constructor(
       encounter.type.getOrNull(0)?.id,
       encounter.type.getOrNull(0)?.text,
       isSynced,
-      encounter.type.getOrNull(0)?.coding?.getOrNull(0)?.code
+      encounter.type.getOrNull(0)?.coding?.getOrNull(0)?.code,
     )
   }
 

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientDetailsViewModel.kt
@@ -195,8 +195,8 @@ constructor(
       visitDate,
       encounter.type.getOrNull(0)?.id,
       encounter.type.getOrNull(0)?.text,
-      "assessment.json",
       isSynced,
+      encounter.type.getOrNull(0)?.coding?.getOrNull(0)?.code
     )
   }
 

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientListViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/PatientListViewModel.kt
@@ -199,8 +199,8 @@ class PatientListViewModel @Inject constructor(private val fhirEngine: FhirEngin
     val dateTime: String,
     val formCode: String?,
     val formDisplay: String?,
-    val formResource: String?,
     val isSynced: Boolean?,
+    val encounterType: String?,
   ) {
     override fun toString(): String = encounterId ?: type
   }

--- a/core/src/main/res/layout/activity_main.xml
+++ b/core/src/main/res/layout/activity_main.xml
@@ -62,6 +62,22 @@
             app:defaultNavHost="true"
         />
 
+    <FrameLayout
+            android:id="@+id/loading_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+        >
+
+        <ProgressBar
+                android:id="@+id/progressBar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminateTint="#4285F4"
+                android:visibility="gone"
+            />
+    </FrameLayout>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.google.android.material.navigation.NavigationView

--- a/core/src/main/res/layout/create_encounter_fragment.xml
+++ b/core/src/main/res/layout/create_encounter_fragment.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<LinearLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/button_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp"
+    android:fillViewport="true"
 >
 
-    <!-- Other views can be added here -->
+    <LinearLayout
+        android:id="@+id/button_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"
+    >
 
-  </LinearLayout>
+        <!-- Other views can be added here -->
+
+    </LinearLayout>
+
+</ScrollView>

--- a/core/src/main/res/navigation/reference_nav_graph.xml
+++ b/core/src/main/res/navigation/reference_nav_graph.xml
@@ -127,7 +127,7 @@
         tools:layout="@layout/generic_formentry_fragment"
     >
     <argument android:name="encounter_id" app:argType="string" />
-    <argument android:name="form_resource" app:argType="string" />
+    <argument android:name="encounter_type" app:argType="string" />
   </fragment>
 
   <fragment

--- a/core/src/main/res/navigation/reference_nav_graph.xml
+++ b/core/src/main/res/navigation/reference_nav_graph.xml
@@ -78,7 +78,6 @@
         android:label="Generic Form Entry"
         tools:layout="@layout/generic_formentry_fragment"
     >
-    <argument android:name="form_resource" app:argType="string" />
     <argument android:name="form_display" app:argType="string" />
     <argument android:name="form_code" app:argType="string" />
     <argument android:name="patient_id" app:argType="string" />
@@ -86,6 +85,11 @@
             android:name="encounter_id"
             app:argType="string"
             android:defaultValue="@null"
+            app:nullable="true"
+        />
+    <argument
+            android:name="questionnaire"
+            app:argType="org.hl7.fhir.r4.model.Questionnaire"
             app:nullable="true"
         />
   </fragment>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="sync_failed_at">Sync: failed at %1$s</string>
     <string name="sync_unknown_state">Sync: unknown state.</string>
     <string name="sync_terminated">Sync: Terminated</string>
+    <string name="logging_out">Logging out..</string>
     <string
         name="sync_device_offline_message"
     >Device Offline. Sync will resume as soon as the device is Online</string>


### PR DESCRIPTION
This development enables the loading of questionnaires from synchronized FHIR entities.

To sync questionnaires, add proper cfg to local.properties eg.:
 
```
 fhir_sync_urls= (...) Questionnaire?_sort=_lastUpdated
```