### PR TITLE
integrated obs group save logic

### DIFF
--- a/core/src/main/java/org/openmrs/android/fhir/Constants.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/Constants.kt
@@ -36,6 +36,7 @@ object Constants {
   val VISIT_TYPE_UUID = "7b0f5697-27e3-40c4-8bae-f4049abfb4ed"
   val VISIT_TYPE_CODE_SYSTEM = "http://fhir.openmrs.org/code-system/visit-type"
   val WRAP_ENCOUNTER = true
+  val CONDITION_CATEGORY_SYSTEM_URL = "http://terminology.hl7.org/CodeSystem/condition-category"
 
   // FHIR URLs
   val PATIENT_LOCATION_IDENTIFIER_URL = "http://fhir.openmrs.org/ext/patient/identifier#location"

--- a/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
@@ -516,7 +516,9 @@ class MainActivity : AppCompatActivity() {
    * Clears app data except AuthStateManager's datastore
    */
   private suspend fun clearAppData() {
-    WorkManager.getInstance(this@MainActivity).cancelAllWork()
+    val workManager = WorkManager.getInstance(this@MainActivity)
+    workManager.cancelAllWork()
+    workManager.pruneWork()
     fhirEngine.clearDatabase()
     demoDataStore.clearAll()
     database.clearAllTables()
@@ -524,6 +526,7 @@ class MainActivity : AppCompatActivity() {
     BiometricUtils.deleteBiometricKey(applicationContext)
     checkAndDeleteLogFile(applicationContext)
     clearApplicationFiles()
+    applicationContext.dataStore.edit { it.clear() }
   }
 
   private fun clearApplicationFiles() {
@@ -533,7 +536,14 @@ class MainActivity : AppCompatActivity() {
         applicationContext.cacheDir,
         applicationContext.getExternalFilesDir(null),
       )
-    dirs.forEach { dir -> dir?.listFiles()?.forEach { file -> file.deleteRecursively() } }
+    dirs.forEach { dir ->
+      dir?.listFiles()?.forEach { file ->
+        if (dir == applicationContext.filesDir && file.name == "datastore") {
+          return@forEach
+        }
+        file.deleteRecursively()
+      }
+    }
   }
 
   private fun handleAuthNavigation(

--- a/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/MainActivity.kt
@@ -526,7 +526,6 @@ class MainActivity : AppCompatActivity() {
     BiometricUtils.deleteBiometricKey(applicationContext)
     checkAndDeleteLogFile(applicationContext)
     clearApplicationFiles()
-    applicationContext.dataStore.edit { it.clear() }
   }
 
   private fun clearApplicationFiles() {

--- a/core/src/main/java/org/openmrs/android/fhir/data/remote/ApiManager.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/data/remote/ApiManager.kt
@@ -98,8 +98,8 @@ class ApiManager @Inject constructor(context: Context) : Api {
       .create(FhirApiService::class.java)
   }
 
-  override suspend fun setLocationSession(sessionLocation: SessionLocation): ApiResponse<Any> {
-    return executeApiHelper { apiService.setLocationSession(sessionLocation) }
+  override suspend fun setLocationSession(sessionLocationMap: SessionLocation): ApiResponse<Any> {
+    return executeApiHelper { apiService.setLocationSession(sessionLocationMap) }
   }
 
   override suspend fun getIdentifier(idType: String): ApiResponse<IdentifierWrapper> {

--- a/core/src/main/java/org/openmrs/android/fhir/util/ObservationGroupUtils.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/util/ObservationGroupUtils.kt
@@ -1,0 +1,311 @@
+/*
+* BSD 3-Clause License
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived from
+*    this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.openmrs.android.fhir.util
+
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.CodeableConcept
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.DateTimeType
+import org.hl7.fhir.r4.model.DateType
+import org.hl7.fhir.r4.model.DecimalType
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Observation
+import org.hl7.fhir.r4.model.Quantity
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.StringType
+import org.hl7.fhir.r4.model.TimeType
+import org.hl7.fhir.r4.model.Type
+
+internal const val OBSERVATION_CHILD_EXTENSION_URL = "http://fhir.openmrs.org/ext/observation-child"
+
+internal data class ObservationChildInfo(
+  val childLinkId: String,
+  val childCodingKeys: Set<CodingKey>,
+  val parentCoding: Coding,
+  val parentCodingKey: CodingKey,
+  val expectedValueTokens: Set<String>,
+)
+
+internal data class ParentKey(
+  val parentCodingKey: CodingKey,
+)
+
+internal data class CodingKey(val system: String?, val code: String?) {
+  fun isValid(): Boolean = !system.isNullOrBlank() || !code.isNullOrBlank()
+
+  fun tokens(): Set<String> {
+    val tokens = mutableSetOf<String>()
+    if (!system.isNullOrBlank() && !code.isNullOrBlank()) {
+      tokens.add("$system|$code")
+    }
+    if (!code.isNullOrBlank()) {
+      tokens.add(code)
+    }
+    if (!system.isNullOrBlank()) {
+      tokens.add(system)
+    }
+    return tokens
+  }
+
+  companion object {
+    fun fromCoding(coding: Coding): CodingKey = CodingKey(coding.system, coding.code)
+  }
+}
+
+/*
+ *
+ * Returns the ObservationChildInfo definition that corresponds to the supplied Observation.
+ * Candidate definitions are gathered by matching each coding on the Observation against the
+ * precomputed child-info map, then value-comparison tokens are used to disambiguate when multiple
+ * candidates share the same coding. Null is returned when no child definition matches.
+ */
+internal fun findObservationChildInfo(
+  observation: Observation,
+  childInfosByCodingKey: Map<CodingKey, List<ObservationChildInfo>>,
+): ObservationChildInfo? {
+  if (!observation.hasCode()) {
+    return null
+  }
+
+  val candidateInfos =
+    observation.code.coding
+      .flatMap { coding -> childInfosByCodingKey[CodingKey.fromCoding(coding)] ?: emptyList() }
+      .distinct()
+
+  if (candidateInfos.isEmpty()) {
+    return null
+  }
+
+  if (candidateInfos.size == 1) {
+    return candidateInfos.first()
+  }
+
+  val observationTokens = observation.value.toComparisonTokens()
+  if (observationTokens.isEmpty()) {
+    return candidateInfos.first()
+  }
+
+  val matchingInfos =
+    candidateInfos.filter { info ->
+      info.expectedValueTokens.isEmpty() ||
+        observationTokens.any { token -> info.expectedValueTokens.contains(token) }
+    }
+
+  return when {
+    matchingInfos.size == 1 -> matchingInfos.first()
+    matchingInfos.isNotEmpty() -> matchingInfos.first()
+    else -> candidateInfos.first()
+  }
+}
+
+/**
+ * Walks the questionnaire (and its response) to enumerate every observation-child item. For each
+ * child question it captures the question’s link ID, all codings found in the response or initial
+ * value, the parent observation coding advertised by the extension, and any comparison tokens
+ * derived from sibling value items in the same group.
+ */
+internal fun collectObservationChildInfos(
+  questionnaire: Questionnaire,
+  questionnaireResponse: QuestionnaireResponse,
+): List<ObservationChildInfo> {
+  val responseItemsByLinkId =
+    mutableMapOf<String, QuestionnaireResponse.QuestionnaireResponseItemComponent>()
+  collectResponseItems(questionnaireResponse.item, responseItemsByLinkId)
+
+  data class GroupContext(
+    val valueLinkIds: MutableSet<String> = mutableSetOf(),
+  )
+
+  val groupStack = mutableListOf<GroupContext>()
+  val childInfos = mutableListOf<ObservationChildInfo>()
+
+  fun traverse(item: Questionnaire.QuestionnaireItemComponent) {
+    val currentContext = groupStack.lastOrNull()
+
+    if (currentContext != null && item.isObservationValueItem()) {
+      currentContext.valueLinkIds.add(item.linkId)
+    }
+
+    if (item.hasObservationChildExtension()) {
+      val parentCoding = item.observationParentCoding() ?: return
+      val parentCodingKey = CodingKey.fromCoding(parentCoding)
+      if (!parentCodingKey.isValid()) {
+        return
+      }
+      val childCodingKeys = resolveChildCodingKeys(item, responseItemsByLinkId)
+      if (childCodingKeys.isEmpty()) {
+        return
+      }
+      val valueTokens =
+        currentContext
+          ?.valueLinkIds
+          ?.flatMap { linkId -> responseItemsByLinkId[linkId]?.answerTokens() ?: emptySet() }
+          ?.toSet()
+          ?: emptySet()
+      childInfos.add(
+        ObservationChildInfo(
+          childLinkId = item.linkId,
+          childCodingKeys = childCodingKeys,
+          parentCoding = parentCoding.copy(),
+          parentCodingKey = parentCodingKey,
+          expectedValueTokens = valueTokens,
+        ),
+      )
+    }
+
+    if (item.type == Questionnaire.QuestionnaireItemType.GROUP) {
+      groupStack.add(GroupContext())
+      item.item.forEach { traverse(it) }
+      groupStack.removeAt(groupStack.lastIndex)
+    } else {
+      item.item.forEach { traverse(it) }
+    }
+  }
+
+  questionnaire.item.forEach { traverse(it) }
+
+  return childInfos
+}
+
+private fun collectResponseItems(
+  items: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+  result: MutableMap<String, QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+) {
+  items.forEach { item ->
+    val linkId = item.linkId
+    if (!linkId.isNullOrBlank()) {
+      result[linkId] = item
+    }
+    collectResponseItems(item.item, result)
+  }
+}
+
+private fun resolveChildCodingKeys(
+  childItem: Questionnaire.QuestionnaireItemComponent,
+  responseItemsByLinkId: Map<String, QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+): Set<CodingKey> {
+  val keys = mutableSetOf<CodingKey>()
+  responseItemsByLinkId[childItem.linkId]?.answer?.forEach { answer ->
+    when (val value = answer.value) {
+      is Coding -> {
+        val key = CodingKey.fromCoding(value)
+        if (key.isValid()) {
+          keys.add(key)
+        }
+      }
+      is CodeableConcept -> {
+        value.coding.forEach { coding ->
+          val key = CodingKey.fromCoding(coding)
+          if (key.isValid()) {
+            keys.add(key)
+          }
+        }
+      }
+    }
+  }
+
+  if (keys.isEmpty()) {
+    childItem.initial
+      .mapNotNull { it.value }
+      .forEach { initialValue ->
+        when (initialValue) {
+          is Coding -> {
+            val key = CodingKey.fromCoding(initialValue)
+            if (key.isValid()) {
+              keys.add(key)
+            }
+          }
+          is CodeableConcept -> {
+            initialValue.coding.forEach { coding ->
+              val key = CodingKey.fromCoding(coding)
+              if (key.isValid()) {
+                keys.add(key)
+              }
+            }
+          }
+        }
+      }
+  }
+
+  return keys
+}
+
+private fun QuestionnaireResponse.QuestionnaireResponseItemComponent.answerTokens(): Set<String> {
+  if (answer.isEmpty()) {
+    return emptySet()
+  }
+  return answer.flatMap { it.value.toComparisonTokens() }.toSet()
+}
+
+private fun Questionnaire.QuestionnaireItemComponent.isObservationValueItem(): Boolean {
+  val definition = definition ?: return false
+  return definition.contains("Observation#Observation.value") ||
+    definition.contains("Observation.value")
+}
+
+private fun Questionnaire.QuestionnaireItemComponent.hasObservationChildExtension(): Boolean {
+  return getExtensionByUrl(OBSERVATION_CHILD_EXTENSION_URL) != null
+}
+
+private fun Questionnaire.QuestionnaireItemComponent.observationParentCoding(): Coding? {
+  return getExtensionByUrl(OBSERVATION_CHILD_EXTENSION_URL)?.value as? Coding
+}
+
+private fun Type?.toComparisonTokens(): Set<String> =
+  when (this) {
+    null -> emptySet()
+    is CodeableConcept -> this.coding.firstOrNull()?.let { CodingKey.fromCoding(it).tokens() }
+        ?: emptySet()
+    is Coding -> CodingKey.fromCoding(this).tokens()
+    is StringType -> this.value?.takeIf { it.isNotBlank() }?.let { setOf(it) } ?: emptySet()
+    is IntegerType -> this.value?.let { setOf(it.toString()) } ?: emptySet()
+    is DecimalType -> this.value?.let { setOf(it.toPlainString()) } ?: emptySet()
+    is BooleanType -> this.value?.let { setOf(it.toString()) } ?: emptySet()
+    is DateType -> this.valueAsString.takeIf { it.isNotBlank() }?.let { setOf(it) } ?: emptySet()
+    is DateTimeType -> this.valueAsString.takeIf { it.isNotBlank() }?.let { setOf(it) }
+        ?: emptySet()
+    is TimeType -> this.value?.takeIf { it.isNotBlank() }?.let { setOf(it) } ?: emptySet()
+    is Quantity -> {
+      val tokens = mutableSetOf<String>()
+      val valuePart = this.value?.toPlainString()
+      val unitPart = this.unit
+      if (!valuePart.isNullOrBlank()) {
+        tokens.add(valuePart)
+      }
+      if (!unitPart.isNullOrBlank()) {
+        tokens.add(unitPart)
+      }
+      if (!valuePart.isNullOrBlank() || !unitPart.isNullOrBlank()) {
+        tokens.add(listOfNotNull(valuePart, unitPart).joinToString("|"))
+      }
+      tokens
+    }
+    else -> setOf(toString())
+  }

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/EditEncounterViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/EditEncounterViewModel.kt
@@ -50,6 +50,7 @@ import kotlin.collections.forEach
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.CodeableConcept
+import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Condition
 import org.hl7.fhir.r4.model.Encounter
 import org.hl7.fhir.r4.model.Observation
@@ -59,6 +60,8 @@ import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.model.StringType
+import org.hl7.fhir.r4.model.codesystems.ConditionCategory
+import org.openmrs.android.fhir.Constants
 import org.openmrs.android.fhir.di.ViewModelAssistedFactory
 import org.openmrs.android.fhir.extensions.convertDateAnswersToUtcDateTime
 import org.openmrs.android.fhir.extensions.convertDateTimeAnswersToDate
@@ -491,6 +494,19 @@ constructor(
     }
     resource.subject = subjectReference
     resource.encounter = encounterReference
+    resource.category =
+      listOf(
+        CodeableConcept().apply {
+          coding =
+            listOf(
+              Coding().apply {
+                system = Constants.CONDITION_CATEGORY_SYSTEM_URL
+                code = ConditionCategory.ENCOUNTERDIAGNOSIS.toCode()
+                display = ConditionCategory.ENCOUNTERDIAGNOSIS.display
+              },
+            )
+        },
+      )
 
     updateResourceToDatabase(resource)
   }

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -373,7 +373,6 @@ constructor(
     patientReference: Reference,
     encounterReference: Reference,
   ): Observation {
-    val parentValue = info.parentDisplay?.takeIf { it.isNotBlank() } ?: info.parentCoding.code
     return Observation().apply {
       id = generateUuid()
       code = CodeableConcept().addCoding(info.parentCoding.copy())
@@ -381,7 +380,6 @@ constructor(
       encounter = encounterReference
       status = Observation.ObservationStatus.FINAL
       effective = nowUtcDateTime()
-      parentValue?.let { this.value = StringType(it) }
     }
   }
 
@@ -468,7 +466,6 @@ constructor(
             childCodingKeys = childCodingKeys,
             parentCoding = parentCoding.copy(),
             parentCodingKey = parentCodingKey,
-            parentDisplay = parentCoding.display,
             expectedValueTokens = valueTokens,
           ),
         )
@@ -609,7 +606,6 @@ constructor(
     val childCodingKeys: Set<CodingKey>,
     val parentCoding: Coding,
     val parentCodingKey: CodingKey,
-    val parentDisplay: String?,
     val expectedValueTokens: Set<String>,
   )
 

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -46,26 +46,17 @@ import dagger.assisted.AssistedInject
 import java.util.Date
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Condition
-import org.hl7.fhir.r4.model.DateTimeType
-import org.hl7.fhir.r4.model.DateType
-import org.hl7.fhir.r4.model.DecimalType
 import org.hl7.fhir.r4.model.Encounter
-import org.hl7.fhir.r4.model.IntegerType
 import org.hl7.fhir.r4.model.Observation
 import org.hl7.fhir.r4.model.Period
-import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Resource
-import org.hl7.fhir.r4.model.StringType
-import org.hl7.fhir.r4.model.TimeType
-import org.hl7.fhir.r4.model.Type
 import org.openmrs.android.fhir.Constants
 import org.openmrs.android.fhir.auth.dataStore
 import org.openmrs.android.fhir.data.OpenMRSHelper
@@ -75,6 +66,10 @@ import org.openmrs.android.fhir.extensions.convertDateAnswersToUtcDateTime
 import org.openmrs.android.fhir.extensions.generateUuid
 import org.openmrs.android.fhir.extensions.getQuestionnaireOrFromAssets
 import org.openmrs.android.fhir.extensions.nowUtcDateTime
+import org.openmrs.android.fhir.util.ObservationChildInfo
+import org.openmrs.android.fhir.util.ParentKey
+import org.openmrs.android.fhir.util.collectObservationChildInfos
+import org.openmrs.android.fhir.util.findObservationChildInfo
 
 /** ViewModel for Generic questionnaire screen {@link GenericFormEntryFragment}. */
 class GenericFormEntryViewModel
@@ -383,265 +378,8 @@ constructor(
     }
   }
 
-  private fun findObservationChildInfo(
-    observation: Observation,
-    childInfosByCodingKey: Map<CodingKey, List<ObservationChildInfo>>,
-  ): ObservationChildInfo? {
-    if (!observation.hasCode()) {
-      return null
-    }
-
-    val candidateInfos =
-      observation.code.coding
-        .flatMap { coding -> childInfosByCodingKey[CodingKey.fromCoding(coding)] ?: emptyList() }
-        .distinct()
-
-    if (candidateInfos.isEmpty()) {
-      return null
-    }
-
-    if (candidateInfos.size == 1) {
-      return candidateInfos.first()
-    }
-
-    val observationTokens = observation.value.toComparisonTokens()
-    if (observationTokens.isEmpty()) {
-      return candidateInfos.first()
-    }
-
-    val matchingInfos =
-      candidateInfos.filter { info ->
-        info.expectedValueTokens.isEmpty() ||
-          observationTokens.any { token -> info.expectedValueTokens.contains(token) }
-      }
-
-    return when {
-      matchingInfos.size == 1 -> matchingInfos.first()
-      matchingInfos.isNotEmpty() -> matchingInfos.first()
-      else -> candidateInfos.first()
-    }
-  }
-
-  private fun collectObservationChildInfos(
-    questionnaire: Questionnaire,
-    questionnaireResponse: QuestionnaireResponse,
-  ): List<ObservationChildInfo> {
-    val responseItemsByLinkId =
-      mutableMapOf<String, QuestionnaireResponse.QuestionnaireResponseItemComponent>()
-    collectResponseItems(questionnaireResponse.item, responseItemsByLinkId)
-
-    data class GroupContext(
-      val valueLinkIds: MutableSet<String> = mutableSetOf(),
-    )
-
-    val groupStack = mutableListOf<GroupContext>()
-    val childInfos = mutableListOf<ObservationChildInfo>()
-
-    fun traverse(item: Questionnaire.QuestionnaireItemComponent) {
-      val currentContext = groupStack.lastOrNull()
-
-      if (currentContext != null && item.isObservationValueItem()) {
-        currentContext.valueLinkIds.add(item.linkId)
-      }
-
-      if (item.hasObservationChildExtension()) {
-        val parentCoding = item.observationChildCoding() ?: return
-        val parentCodingKey = CodingKey.fromCoding(parentCoding)
-        if (!parentCodingKey.isValid()) {
-          return
-        }
-        val childCodingKeys = resolveChildCodingKeys(item, responseItemsByLinkId)
-        if (childCodingKeys.isEmpty()) {
-          return
-        }
-        val valueTokens =
-          currentContext
-            ?.valueLinkIds
-            ?.flatMap { linkId -> responseItemsByLinkId[linkId]?.answerTokens() ?: emptySet() }
-            ?.toSet()
-            ?: emptySet()
-        childInfos.add(
-          ObservationChildInfo(
-            childLinkId = item.linkId,
-            childCodingKeys = childCodingKeys,
-            parentCoding = parentCoding.copy(),
-            parentCodingKey = parentCodingKey,
-            expectedValueTokens = valueTokens,
-          ),
-        )
-      }
-
-      if (item.type == Questionnaire.QuestionnaireItemType.GROUP) {
-        groupStack.add(GroupContext())
-        item.item.forEach { traverse(it) }
-        groupStack.removeAt(groupStack.lastIndex)
-      } else {
-        item.item.forEach { traverse(it) }
-      }
-    }
-
-    questionnaire.item.forEach { traverse(it) }
-
-    return childInfos
-  }
-
-  private fun collectResponseItems(
-    items: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
-    result: MutableMap<String, QuestionnaireResponse.QuestionnaireResponseItemComponent>,
-  ) {
-    items.forEach { item ->
-      val linkId = item.linkId
-      if (!linkId.isNullOrBlank()) {
-        result[linkId] = item
-      }
-      collectResponseItems(item.item, result)
-    }
-  }
-
-  private fun resolveChildCodingKeys(
-    childItem: Questionnaire.QuestionnaireItemComponent,
-    responseItemsByLinkId: Map<String, QuestionnaireResponse.QuestionnaireResponseItemComponent>,
-  ): Set<CodingKey> {
-    val keys = mutableSetOf<CodingKey>()
-    responseItemsByLinkId[childItem.linkId]?.answer?.forEach { answer ->
-      when (val value = answer.value) {
-        is Coding -> {
-          val key = CodingKey.fromCoding(value)
-          if (key.isValid()) {
-            keys.add(key)
-          }
-        }
-        is CodeableConcept -> {
-          value.coding.forEach { coding ->
-            val key = CodingKey.fromCoding(coding)
-            if (key.isValid()) {
-              keys.add(key)
-            }
-          }
-        }
-      }
-    }
-
-    if (keys.isEmpty()) {
-      childItem.initial
-        .mapNotNull { it.value }
-        .forEach { initialValue ->
-          when (initialValue) {
-            is Coding -> {
-              val key = CodingKey.fromCoding(initialValue)
-              if (key.isValid()) {
-                keys.add(key)
-              }
-            }
-            is CodeableConcept -> {
-              initialValue.coding.forEach { coding ->
-                val key = CodingKey.fromCoding(coding)
-                if (key.isValid()) {
-                  keys.add(key)
-                }
-              }
-            }
-          }
-        }
-    }
-
-    return keys
-  }
-
-  private fun QuestionnaireResponse.QuestionnaireResponseItemComponent.answerTokens(): Set<String> {
-    if (answer.isEmpty()) {
-      return emptySet()
-    }
-    return answer.flatMap { it.value.toComparisonTokens() }.toSet()
-  }
-
-  private fun Questionnaire.QuestionnaireItemComponent.isObservationValueItem(): Boolean {
-    val definition = definition ?: return false
-    return definition.contains("Observation#Observation.value") ||
-      definition.contains("Observation.value")
-  }
-
-  private fun Questionnaire.QuestionnaireItemComponent.hasObservationChildExtension(): Boolean {
-    return getExtensionByUrl(OBSERVATION_CHILD_EXTENSION_URL) != null
-  }
-
-  private fun Questionnaire.QuestionnaireItemComponent.observationChildCoding(): Coding? {
-    return getExtensionByUrl(OBSERVATION_CHILD_EXTENSION_URL)?.value as? Coding
-  }
-
-  private fun Type?.toComparisonTokens(): Set<String> =
-    when (this) {
-      null -> emptySet()
-      is CodeableConcept -> this.coding.firstOrNull()?.let { CodingKey.fromCoding(it).tokens() }
-          ?: emptySet()
-      is Coding -> CodingKey.fromCoding(this).tokens()
-      is StringType -> this.value?.takeIf { it.isNotBlank() }?.let { setOf(it) } ?: emptySet()
-      is IntegerType -> this.value?.let { setOf(it.toString()) } ?: emptySet()
-      is DecimalType -> this.value?.let { setOf(it.toPlainString()) } ?: emptySet()
-      is BooleanType -> this.value?.let { setOf(it.toString()) } ?: emptySet()
-      is DateType -> this.valueAsString.takeIf { it.isNotBlank() }?.let { setOf(it) } ?: emptySet()
-      is DateTimeType -> this.valueAsString.takeIf { it.isNotBlank() }?.let { setOf(it) }
-          ?: emptySet()
-      is TimeType -> this.value?.takeIf { it.isNotBlank() }?.let { setOf(it) } ?: emptySet()
-      is Quantity -> {
-        val tokens = mutableSetOf<String>()
-        val valuePart = this.value?.toPlainString()
-        val unitPart = this.unit
-        if (!valuePart.isNullOrBlank()) {
-          tokens.add(valuePart)
-        }
-        if (!unitPart.isNullOrBlank()) {
-          tokens.add(unitPart)
-        }
-        if (!valuePart.isNullOrBlank() || !unitPart.isNullOrBlank()) {
-          tokens.add(listOfNotNull(valuePart, unitPart).joinToString("|"))
-        }
-        tokens
-      }
-      else -> setOf(toString())
-    }
-
-  private data class ObservationChildInfo(
-    val childLinkId: String,
-    val childCodingKeys: Set<CodingKey>,
-    val parentCoding: Coding,
-    val parentCodingKey: CodingKey,
-    val expectedValueTokens: Set<String>,
-  )
-
-  private data class ParentKey(
-    val parentCodingKey: CodingKey,
-  )
-
-  private data class CodingKey(val system: String?, val code: String?) {
-    fun isValid(): Boolean = !system.isNullOrBlank() || !code.isNullOrBlank()
-
-    fun tokens(): Set<String> {
-      val tokens = mutableSetOf<String>()
-      if (!system.isNullOrBlank() && !code.isNullOrBlank()) {
-        tokens.add("$system|$code")
-      }
-      if (!code.isNullOrBlank()) {
-        tokens.add(code)
-      }
-      if (!system.isNullOrBlank()) {
-        tokens.add(system)
-      }
-      return tokens
-    }
-
-    companion object {
-      fun fromCoding(coding: Coding): CodingKey = CodingKey(coding.system, coding.code)
-    }
-  }
-
   private suspend fun saveResourceToDatabase(resource: Resource) {
     fhirEngine.create(resource)
-  }
-
-  private companion object {
-    private const val OBSERVATION_CHILD_EXTENSION_URL =
-      "http://fhir.openmrs.org/ext/observation-child"
   }
 
   fun updateQuestionnaire(updated: Questionnaire) {

--- a/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/viewmodel/GenericFormEntryViewModel.kt
@@ -57,6 +57,7 @@ import org.hl7.fhir.r4.model.Questionnaire
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Resource
+import org.hl7.fhir.r4.model.codesystems.ConditionCategory
 import org.openmrs.android.fhir.Constants
 import org.openmrs.android.fhir.auth.dataStore
 import org.openmrs.android.fhir.data.OpenMRSHelper
@@ -327,6 +328,20 @@ constructor(
             resource.id = generateUuid()
             resource.subject = patientReference
             resource.encounter = encounterReference
+            // Current requirement for encounter-diagnosis only.
+            resource.category =
+              listOf(
+                CodeableConcept().apply {
+                  coding =
+                    listOf(
+                      Coding().apply {
+                        system = Constants.CONDITION_CATEGORY_SYSTEM_URL
+                        code = ConditionCategory.ENCOUNTERDIAGNOSIS.toCode()
+                        display = ConditionCategory.ENCOUNTERDIAGNOSIS.display
+                      },
+                    )
+                },
+              )
             saveResourceToDatabase(resource)
           }
         }


### PR DESCRIPTION
Handles child observation save logic
Notes:
1. Saves parent observation before child
2. Handles case where obsgroup has multiple children.
3. Handles case when observations with same code has different parents. 
4. Currently does not handle the case of same code with same parent obsgroup code but different parent obsgroup. (repeated group)