### PR TITLE
Implemented group-scoped timestamp storage

### DIFF
--- a/core/src/main/java/org/openmrs/android/fhir/DemoDataStore.kt
+++ b/core/src/main/java/org/openmrs/android/fhir/DemoDataStore.kt
@@ -51,12 +51,24 @@ private val Context.dataStorage: DataStore<Preferences> by
  */
 class DemoDataStore(private val context: Context) {
 
-  suspend fun saveLastUpdatedTimestamp(resourceType: ResourceType, timestamp: String) {
-    context.dataStorage.edit { pref -> pref[stringPreferencesKey(resourceType.name)] = timestamp }
+  suspend fun saveLastUpdatedTimestamp(
+    resourceType: ResourceType,
+    timestamp: String,
+    groupId: String? = null,
+  ) {
+    context.dataStorage.edit { pref ->
+      pref[stringPreferencesKey(resourceType.buildKey(groupId))] = timestamp
+    }
   }
 
-  suspend fun getLasUpdateTimestamp(resourceType: ResourceType): String? {
-    return context.dataStorage.data.first()[stringPreferencesKey(resourceType.name)]
+  suspend fun getLastUpdateTimestamp(resourceType: ResourceType, groupId: String? = null): String? {
+    return context.dataStorage.data.first()[stringPreferencesKey(resourceType.buildKey(groupId))]
+  }
+
+  suspend fun clearLastUpdatedTimestamp(resourceType: ResourceType, groupId: String? = null) {
+    context.dataStorage.edit { pref ->
+      pref.remove(stringPreferencesKey(resourceType.buildKey(groupId)))
+    }
   }
 
   suspend fun saveTokenExpiryDelay(time: String) {
@@ -104,5 +116,13 @@ class DemoDataStore(private val context: Context) {
     const val CHECK_NETWORK_CONNECTIVITY = "check-network-connectivity"
     const val INITIAL_TOKEN_CHECK_DELAY: Long = 1
     const val INITIAL_PERIODIC_SYNC_DELAY: Long = 15
+  }
+}
+
+private fun ResourceType.buildKey(groupId: String?): String {
+  return if (groupId.isNullOrBlank()) {
+    name
+  } else {
+    "$name-$groupId"
   }
 }


### PR DESCRIPTION
Fixes #228 

Implemented group-scoped timestamp storage by composing last-updated keys from resource type and optional group identifiers, allowing DemoDataStore to save, fetch, and clear per-group sync markers without affecting other resources.

Refactored timestamp-based download management to enqueue patient requests per selected group, propagate group context through download and summary URLs, and reuse scoped timestamps across pagination and $everything flows while clearing legacy combined patient keys.